### PR TITLE
missing SonataCoreBundle()

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -26,6 +26,7 @@ class AppKernel extends Kernel
             new Knp\Bundle\PaginatorBundle\KnpPaginatorBundle(),
             new Mopa\Bundle\BootstrapBundle\MopaBootstrapBundle(),
             new FOS\UserBundle\FOSUserBundle(),
+            new Sonata\CoreBundle\SonataCoreBundle(),
             new Sonata\AdminBundle\SonataAdminBundle(),
             new Sonata\UserBundle\SonataUserBundle('FOSUserBundle'),
             new Sonata\jQueryBundle\SonatajQueryBundle(),


### PR DESCRIPTION
SonataCoreBundle was missing from the AppKernel and this is crashing the sandbox installation
