### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ It comes pre-configured with the following bundles:
     integrated with in a SonataAdmin setup.
 
   * [**IbrowsSonataAdminAnnotationBundle**][19] - Adds the ability to defined form fields via annotations
-    to be used in conjuction with the SonataAdminBundle
+    to be used in conjunction with the SonataAdminBundle
 
 
 [1]:  http://web.networking.ch


### PR DESCRIPTION
@networking, I've corrected a typographical error in the documentation of the [init-cms-sandbox](https://github.com/networking/init-cms-sandbox) project. Specifically, I've changed conjuction to conjunction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
